### PR TITLE
Switch-over to Alpine as a base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,29 @@
-FROM jlesage/baseimage-gui:ubuntu-16.04
+FROM alpine:latest
 
 ENV APP_NAME="iDRAC 6" \
-    IDRAC_PORT=443
+    IDRAC_PORT=443 \
+    USER_ID="nobody" \
+    GROUP_ID="nobody"
 
+# --- refresh to current packages
+RUN apk update && \
+    apk upgrade && \
+    apk add build-base libx11-dev
+
+# --- build the keycode-hack shim
 COPY keycode-hack.c /keycode-hack.c
+RUN gcc -o /keycode-hack.so /keycode-hack.c -shared -s -ldl -fPIC
 
-RUN apt-get update && \
-    apt-get install -y wget software-properties-common && \
-    add-apt-repository ppa:openjdk-r/ppa && \
-    apt-get update && \
-    apt-get install -y openjdk-7-jdk gcc && \
-    gcc -o /keycode-hack.so /keycode-hack.c -shared -s -ldl -fPIC && \
-    apt-get remove -y gcc software-properties-common && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm /keycode-hack.c
+# --- clean up the prior build and prep Java 7 for use
+RUN apk del build-base libx11-dev && \
+    apk update --repository edge && \
+    apk add --repository edge openjdk7-jre wget
 
 RUN mkdir /app && \
     chown ${USER_ID}:${GROUP_ID} /app
 
+
 COPY startapp.sh /startapp.sh
+
 
 WORKDIR /app


### PR DESCRIPTION
This is a complete switch-over to using Alpine as the build base.  Doing so will eliminate several megabytes of storage required for the completed image.  The build process completes but I have not tested it as of yet.